### PR TITLE
Switch from .gitignore to COPYING

### DIFF
--- a/src/journal.lisp
+++ b/src/journal.lisp
@@ -5179,7 +5179,7 @@
        t))))
 
 (defparameter *file-position-works-p*
-  (with-open-file (s (asdf:system-relative-pathname "journal" ".gitignore"))
+  (with-open-file (s (asdf:system-relative-pathname "journal" "COPYING"))
     (read-line s)
     (file-position s 0)
     (cond


### PR DESCRIPTION
COPYING is a better choice because .gitignore may not be in every distribution of the source code.